### PR TITLE
Adapt actuator-provider to the latest zenoh-pico version

### DIFF
--- a/components/actuator-provider/platformio.ini
+++ b/components/actuator-provider/platformio.ini
@@ -15,10 +15,10 @@
 platform = espressif32
 board = upesy_wroom
 framework = espidf
-lib_deps = https://github.com/eclipse-zenoh/zenoh-pico#0.11.0
+lib_deps = https://github.com/eclipse-zenoh/zenoh-pico#1.3.4
 monitor_speed = 115200
 monitor_rts = 0
 monitor_dtr = 0
 monitor_filters = direct
 
-build_flags = -DZENOH_ESPIDF -DZ_BATCH_UNICAST_SIZE=1024 -DZ_BATCH_MULTICAST_SIZE=1024 -DZ_FRAG_MAX_SIZE=1024 -DZ_CONFIG_SOCKET_TIMEOUT=5000 -DCORE_DEBUG_LEVEL=5
+build_flags = -DZENOH_ESPIDF -DCORE_DEBUG_LEVEL=5

--- a/components/actuator-provider/src/config.h
+++ b/components/actuator-provider/src/config.h
@@ -12,10 +12,10 @@
  ********************************************************************************/
 
 #define CONFIG_H
-/* This uses WiFi configuration that you can set via project configuration menu
+/* This uses Wi-Fi configuration that you can set via project configuration menu
 
-   If you'd rather not, just change the below entries to strings with
-   the config you want - ie #define ESP_WIFI_SSID "mywifissid"
+   If you'd rather not, change the below entries to strings with
+   the config you want - i.e., #define ESP_WIFI_SSID "mywifissid"
 */
 #define ESP_WIFI_SSID                       CONFIG_ESP_WIFI_SSID
 #define ESP_WIFI_PASS                       CONFIG_ESP_WIFI_PASSWORD
@@ -26,18 +26,18 @@
 #if CLIENT_OR_PEER == 0
 #define MODE                                "client"
 /*
-CONNECT specifies the connection string to the Zenoh router.
+LOCATOR specifies the connection string to the Zenoh router.
 Replace <ip> with the IP address of the machine hosting the blueprint Docker setup.
 Format: "tcp/<ip>:7447#iface=docker0".
 */
-#define CONNECT                             ""
+#define LOCATOR                             ""
 #elif CLIENT_OR_PEER == 1
 #define MODE                                "peer"
 /*
- * Hint: Set this to "<protocol>/<ip>:<port>#<interface>" even when CONNECT is empty to configure the scouting mechanism.
+ * Hint: Set this to "<protocol>/<ip>:<port>#<interface>" even when LOCATOR is empty to configure the scouting mechanism.
  * - Zenoh router (zenohd) typically listens on udp/224.0.0.224:7446
 */
-#define CONNECT                             ""
+#define LOCATOR                             ""
 #else
 #error "Unknown Zenoh operation mode. Check CLIENT_OR_PEER value."
 #endif

--- a/components/actuator-provider/src/main.c
+++ b/components/actuator-provider/src/main.c
@@ -5,12 +5,13 @@
  * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
- * terms of the Apache License 2.0 which is available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
+#include "driver/gpio.h"
 #include <esp_event.h>
 #include <esp_log.h>
 #include <esp_system.h>
@@ -19,339 +20,318 @@
 #include <freertos/event_groups.h>
 #include <freertos/task.h>
 #include <nvs_flash.h>
+#include <regex.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <zenoh-pico.h>
-#include "config.h"
-#include "driver/gpio.h"
-#include <regex.h>
 
-#if Z_FEATURE_PUBLICATION == 1
+#include "config.h"
+
+#if Z_FEATURE_SUBSCRIPTION == 1
+#define WIFI_CONNECTED_BIT BIT0
+
 static bool s_is_wifi_connected = false;
 static EventGroupHandle_t s_event_group_handler;
 static int s_retry_count = 0;
 
-static const char *TAG = "MAIN";
-
 static z_owned_publisher_t pub;
 
-typedef enum
-{
-    SIGNAL_TYPE_CURRENT_VALUE,
-    SIGNAL_TYPE_TARGET_VALUE,
-    SIGNAL_TYPE_UNKNOWN
+static const char *TAG = "ACTUATOR PROVIDER";
+
+typedef enum {
+  SIGNAL_TYPE_CURRENT_VALUE,
+  SIGNAL_TYPE_TARGET_VALUE,
+  SIGNAL_TYPE_UNKNOWN
 } signal_type_t;
 
-#if Z_FEATURE_ATTACHMENT == 1
-
-signal_type_t attachment_handler(z_bytes_t key, z_bytes_t value, void *ctx)
-{
-    (void)ctx;
-
-    char type[50] = "";
-    size_t type_len = value.len;
-    strncpy(type, (const char *)value.start, type_len);
-    type[type_len] = '\0';
-
-    if (strcmp(type, "currentValue") == 0)
-    {
-        return SIGNAL_TYPE_CURRENT_VALUE;
-    }
-    else if (strcmp(type, "targetValue") == 0)
-    {
-        return SIGNAL_TYPE_TARGET_VALUE;
-    }
-    else
-    {
-        return SIGNAL_TYPE_UNKNOWN;
-    }
+void gpio_init() {
+  gpio_reset_pin(LED_GPIO);
+  gpio_set_direction(LED_GPIO, GPIO_MODE_OUTPUT);
 }
-#endif
 
-int is_valid_tcp_url(char *url)
-{
-    char pattern[] = "^tcp/.*:[0-9]+$";
-    int result;
-    regex_t reg;
+int is_valid_locator(char *url) {
+  const char pattern[] =
+      "^tcp/([0-9]{1,3}\\.){3}[0-9]{1,3}:[0-9]+#iface=[a-zA-Z0-9_-]+$";
+  regex_t reg;
 
-    if (regcomp(&reg, pattern, REG_EXTENDED | REG_NOSUB) != 0)
-        return -1;
+  int compile_status = regcomp(&reg, pattern, REG_EXTENDED | REG_NOSUB);
+  if (compile_status != 0) {
+    char errbuf[100];
+    regerror(compile_status, &reg, errbuf, sizeof(errbuf));
+    ESP_LOGE(TAG, "Regex compile error: %s\n", errbuf);
+    return -1;
+  }
 
-    result = regexec(&reg, url, 0, 0, 0);
-    regfree(&reg);
+  int result = regexec(&reg, url, 0, NULL, 0);
+  if (result != 0) {
+    char errbuf[100];
+    regerror(result, &reg, errbuf, sizeof(errbuf));
+    ESP_LOGE(TAG, "Regex match error: %s\n", errbuf);
+  }
+
+  regfree(&reg);
+  return result;
+}
+
+void pub_status(const char *value) {
+  const char attachment_payload[] = "currentValue";
+  char buffer[32] = {0};
+
+  snprintf(buffer, sizeof(buffer), "%s", value);
+
+  z_owned_bytes_t attachment;
+  z_bytes_empty(&attachment);
+
+  z_publisher_put_options_t options;
+  z_publisher_put_options_default(&options);
+
+  z_owned_bytes_t payload;
+  z_bytes_copy_from_str(&payload, buffer);
+
+  z_owned_encoding_t encoding;
+  z_encoding_from_str(&encoding, "zenoh/string;utf8");
+
+  z_bytes_copy_from_str(&attachment, attachment_payload);
+
+  options.attachment = z_move(attachment);
+  options.encoding = z_move(encoding);
+
+  ESP_LOGI(TAG, "Publishing message...");
+  z_publisher_put(z_loan(pub), z_move(payload), &options);
+  ESP_LOGI(TAG, "Message published successfully");
+}
+
+signal_type_t attachment_handler(z_loaned_sample_t *sample) {
+  const z_loaned_bytes_t *attachment = z_sample_attachment(sample);
+  if (attachment != NULL) {
+    ze_deserializer_t deserializer = ze_deserializer_from_bytes(attachment);
+    size_t attachment_len;
+    ze_deserializer_deserialize_sequence_length(&deserializer, &attachment_len);
+
+    z_owned_string_t attachment_str;
+    z_bytes_to_string(z_sample_attachment(sample), &attachment_str);
+    ESP_LOGI(TAG, "    with attachment: %.*s\n",
+             (int)z_string_len(z_loan(attachment_str)),
+             z_string_data(z_loan(attachment_str)));
+
+    signal_type_t result = SIGNAL_TYPE_UNKNOWN;
+
+    const char *data = z_string_data(z_loan(attachment_str));
+    size_t len = z_string_len(z_loan(attachment_str));
+
+    if (strncmp(data, "currentValue", len) == 0) {
+      result = SIGNAL_TYPE_CURRENT_VALUE;
+    } else if (strncmp(data, "targetValue", len) == 0) {
+      result = SIGNAL_TYPE_TARGET_VALUE;
+    }
+
+    z_drop(z_move(attachment_str));
 
     return result;
-}
-
-void gpio_init()
-{
-    gpio_reset_pin(LED_GPIO);
-    gpio_set_direction(LED_GPIO, GPIO_MODE_OUTPUT);
-}
-
-void turn_led(bool on)
-{
-    if (on)
-    {
-        gpio_set_level(LED_GPIO, 1);
-    }
-    else if (!on)
-    {
-        gpio_set_level(LED_GPIO, 0);
-    }
-}
-
-void pub_status(char *value_str)
-{
-    char buf[32];
-    sprintf(buf, "%s", value_str);
-
-    z_publisher_put_options_t options = z_publisher_put_options_default();
-    z_owned_bytes_map_t map = z_bytes_map_new();
-    z_bytes_map_insert_by_alias(&map, _z_bytes_wrap((uint8_t *)"type", 4), _z_bytes_wrap((uint8_t *)"currentValue", 12));
-    options.attachment = z_bytes_map_as_attachment(&map);
-
-    z_publisher_put(z_loan(pub), (const uint8_t *)buf, strlen(buf), &options);
-}
-
-char *payload_to_string(const z_bytes_t *payload)
-{
-    char *string = (char *)malloc(payload->len + 1);
-    if (string == NULL)
-    {
-        fprintf(stderr, "Memory allocation failed\n");
-        exit(EXIT_FAILURE);
-    }
-
-    for (size_t i = 0; i < payload->len; i++)
-    {
-        string[i] = payload->start[i];
-    }
-
-    string[payload->len] = '\0';
-
-    return string;
-}
-
-void sample_handler(const z_sample_t *sample, void *arg)
-{
-    z_owned_str_t keystr = z_keyexpr_to_string(sample->keyexpr);
-    ESP_LOGI(TAG, ">> [Subscriber handler] Received ('%s': '%.*s')\n",
-             z_str_loan(&keystr), (int)sample->payload.len,
-             sample->payload.start);
-
-#if Z_FEATURE_ATTACHMENT == 1
-    if (z_attachment_check(&sample->attachment))
-    {
-        int8_t type_result =
-            z_attachment_iterate(sample->attachment, attachment_handler, NULL);
-
-        if (type_result == SIGNAL_TYPE_CURRENT_VALUE)
-        {
-            ESP_LOGI(TAG, "[Subscriber handler] Received currentValue. Discarding signal.\n");
-        }
-        else if (type_result == SIGNAL_TYPE_TARGET_VALUE)
-        {
-            ESP_LOGI(TAG, "[Subscriber handler] Recieved targetValue\n");
-
-            char *value_str = payload_to_string(&sample->payload);
-
-            if (strcmp(value_str, "true") == 0)
-            {
-                ESP_LOGI(TAG, "[Subscriber handler] Activating the horn.\n");
-                turn_led(true);
-
-                pub_status(value_str);
-                free(value_str);
-            }
-            else if (strcmp(value_str, "false") == 0)
-            {
-                ESP_LOGI(TAG, "[Subscriber handler] Turning off the horn.\n");
-                turn_led(false);
-                pub_status(value_str);
-                free(value_str);
-            }
-            else
-            {
-                ESP_LOGI(TAG, "[Subscriber handler] Received a faulty payload value.");
-            }
-        }
-        else if (type_result == SIGNAL_TYPE_UNKNOWN)
-        {
-            ESP_LOGI(TAG, "[Subscriber handler] Received an unknown signal type. Discarding the signal.\n");
-        };
-    };
-#else
-    ESP_LOGI(TAG, "The attachment feature is not enabled but is required for the full functionality.")
-#endif
-
-    z_str_drop(z_str_move(&keystr));
+  }
+  return SIGNAL_TYPE_UNKNOWN;
 }
 
 static void event_handler(void *arg, esp_event_base_t event_base,
-                          int32_t event_id, void *event_data)
-{
-    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START)
-    {
-        esp_wifi_connect();
+                          int32_t event_id, void *event_data) {
+  if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+    esp_wifi_connect();
+  } else if (event_base == WIFI_EVENT &&
+             event_id == WIFI_EVENT_STA_DISCONNECTED) {
+    if (s_retry_count < ESP_MAXIMUM_RETRY) {
+      esp_wifi_connect();
+      s_retry_count++;
     }
-    else if (event_base == WIFI_EVENT &&
-             event_id == WIFI_EVENT_STA_DISCONNECTED)
-    {
-        if (s_retry_count < ESP_MAXIMUM_RETRY)
-        {
-            esp_wifi_connect();
-            s_retry_count++;
-        }
-    }
-    else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP)
-    {
-        xEventGroupSetBits(s_event_group_handler, WIFI_CONNECTED_BIT);
-        s_retry_count = 0;
-    }
+  } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+    xEventGroupSetBits(s_event_group_handler, WIFI_CONNECTED_BIT);
+    s_retry_count = 0;
+  }
 }
 
-void wifi_init_sta(void)
-{
-    s_event_group_handler = xEventGroupCreate();
+void wifi_init_sta(void) {
+  s_event_group_handler = xEventGroupCreate();
 
-    ESP_ERROR_CHECK(esp_netif_init());
+  ESP_ERROR_CHECK(esp_netif_init());
 
-    ESP_ERROR_CHECK(esp_event_loop_create_default());
-    esp_netif_create_default_wifi_sta();
+  ESP_ERROR_CHECK(esp_event_loop_create_default());
+  esp_netif_create_default_wifi_sta();
 
-    wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_wifi_init(&config));
+  wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
+  ESP_ERROR_CHECK(esp_wifi_init(&config));
 
-    esp_event_handler_instance_t handler_any_id;
-    esp_event_handler_instance_t handler_got_ip;
-    ESP_ERROR_CHECK(esp_event_handler_instance_register(
-        WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL, &handler_any_id));
-    ESP_ERROR_CHECK(esp_event_handler_instance_register(
-        IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler, NULL, &handler_got_ip));
+  esp_event_handler_instance_t handler_any_id;
+  esp_event_handler_instance_t handler_got_ip;
+  ESP_ERROR_CHECK(esp_event_handler_instance_register(
+      WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL, &handler_any_id));
+  ESP_ERROR_CHECK(esp_event_handler_instance_register(
+      IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler, NULL, &handler_got_ip));
 
-    wifi_config_t wifi_config = {.sta = {
-                                     .ssid = ESP_WIFI_SSID,
-                                     .password = ESP_WIFI_PASS,
-                                 }};
+  wifi_config_t wifi_config = {.sta = {
+                                   .ssid = ESP_WIFI_SSID,
+                                   .password = ESP_WIFI_PASS,
+                               }};
 
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
-    ESP_ERROR_CHECK(esp_wifi_start());
+  ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+  ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+  ESP_ERROR_CHECK(esp_wifi_start());
 
-    EventBits_t bits =
-        xEventGroupWaitBits(s_event_group_handler, WIFI_CONNECTED_BIT, pdFALSE,
-                            pdFALSE, portMAX_DELAY);
+  EventBits_t bits =
+      xEventGroupWaitBits(s_event_group_handler, WIFI_CONNECTED_BIT, pdFALSE,
+                          pdFALSE, portMAX_DELAY);
 
-    if (bits & WIFI_CONNECTED_BIT)
-    {
-        s_is_wifi_connected = true;
-    }
+  if (bits & WIFI_CONNECTED_BIT) {
+    s_is_wifi_connected = true;
+  }
 
-    ESP_ERROR_CHECK(esp_event_handler_instance_unregister(
-        IP_EVENT, IP_EVENT_STA_GOT_IP, handler_got_ip));
-    ESP_ERROR_CHECK(esp_event_handler_instance_unregister(
-        WIFI_EVENT, ESP_EVENT_ANY_ID, handler_any_id));
-    vEventGroupDelete(s_event_group_handler);
+  ESP_ERROR_CHECK(esp_event_handler_instance_unregister(
+      IP_EVENT, IP_EVENT_STA_GOT_IP, handler_got_ip));
+  ESP_ERROR_CHECK(esp_event_handler_instance_unregister(
+      WIFI_EVENT, ESP_EVENT_ANY_ID, handler_any_id));
+  vEventGroupDelete(s_event_group_handler);
 }
 
-void app_main()
-{
-    esp_err_t ret = nvs_flash_init();
-    if (ret == ESP_ERR_NVS_NO_FREE_PAGES ||
-        ret == ESP_ERR_NVS_NEW_VERSION_FOUND)
-    {
-        ESP_ERROR_CHECK(nvs_flash_erase());
-        ret = nvs_flash_init();
+void data_handler(z_loaned_sample_t *sample, void *ctx) {
+  (void)(ctx);
+  z_view_string_t keystr;
+  z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);
+  z_owned_string_t value;
+  z_bytes_to_string(z_sample_payload(sample), &value);
+  z_owned_string_t encoding;
+  z_encoding_to_string(z_sample_encoding(sample), &encoding);
+
+  ESP_LOGI(TAG, ">> [Subscriber] Received ('%.*s': '%.*s')\n",
+           (int)z_string_len(z_loan(keystr)), z_string_data(z_loan(keystr)),
+           (int)z_string_len(z_loan(value)), z_string_data(z_loan(value)));
+  ESP_LOGI(TAG, "    with encoding: %.*s\n",
+           (int)z_string_len(z_loan(encoding)),
+           z_string_data(z_loan(encoding)));
+
+  // Check timestamp
+  const z_timestamp_t *ts = z_sample_timestamp(sample);
+  if (ts != NULL) {
+    ESP_LOGI(TAG, "    with timestamp: %" PRIu64 "\n",
+             z_timestamp_ntp64_time(ts));
+  }
+
+  // Check attachment
+  signal_type_t signal_type = attachment_handler(sample);
+
+  if (signal_type == SIGNAL_TYPE_CURRENT_VALUE) {
+    ESP_LOGI(TAG, "Received currentValue. Discarding signal.\n");
+  }
+  if (signal_type == SIGNAL_TYPE_TARGET_VALUE) {
+    ESP_LOGI(TAG, "Received targetValue. \n");
+
+    const char *value_data = z_string_data(z_loan(value));
+    size_t value_len = z_string_len(z_loan(value));
+
+    if (value_len == 4 && strncmp(value_data, "true", 4) == 0) {
+      ESP_LOGI(TAG, "Turning on LED.");
+      gpio_set_level(LED_GPIO, 1);
+      pub_status("true");
+    } else if (value_len == 5 && strncmp(value_data, "false", 5) == 0) {
+      ESP_LOGI(TAG, "Turning off LED.");
+      gpio_set_level(LED_GPIO, 0);
+      pub_status("false");
+    } else {
+      ESP_LOGI(TAG, "Received unknown value: '%.*s'\n", (int)value_len,
+               value_data);
     }
-    ESP_ERROR_CHECK(ret);
+  }
+  z_drop(z_move(value));
+  z_drop(z_move(encoding));
+}
 
-    // Set WiFi in STA mode and trigger attachment
-    ESP_LOGI(TAG, "Connecting to WiFi...");
-    wifi_init_sta();
-    while (!s_is_wifi_connected)
-    {
-        printf(".");
-        sleep(1);
+void app_main() {
+
+  esp_log_level_set(TAG, ESP_LOG_DEBUG);
+
+  esp_err_t ret = nvs_flash_init();
+  if (ret == ESP_ERR_NVS_NO_FREE_PAGES ||
+      ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+    ESP_ERROR_CHECK(nvs_flash_erase());
+    ret = nvs_flash_init();
+  }
+  ESP_ERROR_CHECK(ret);
+
+  // Set WiFi in STA mode and trigger attachment
+  ESP_LOGI(TAG, "Connecting to WiFi...");
+  wifi_init_sta();
+  while (!s_is_wifi_connected) {
+    ESP_LOGI(TAG, ".");
+    sleep(1);
+  }
+  ESP_LOGI(TAG, "Establishing the Wifi connection was successful!\n");
+
+  // Initialize GPIO pin with led
+  gpio_init();
+
+  // Initialize Zenoh Session and other parameters
+  z_owned_config_t config;
+  z_config_default(&config);
+  zp_config_insert(z_loan_mut(config), Z_CONFIG_MODE_KEY, MODE);
+  if (is_valid_locator(LOCATOR) != 0) {
+    ESP_LOGE(TAG, "Invalid locator format. Please use "
+                  "'tcp/<ip>:<port>#<interface>' format.");
+    exit(-1);
+  }
+  if (strcmp(LOCATOR, "") != 0) {
+    if (strcmp(MODE, "client") == 0) {
+      zp_config_insert(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, LOCATOR);
+    } else {
+      zp_config_insert(z_loan_mut(config), Z_CONFIG_LISTEN_KEY, LOCATOR);
     }
-    ESP_LOGI(TAG, "Establishing the Wifi connection was successful!\n");
+  }
 
-    // Initialize GPIO pin with led
-    gpio_init();
+  // Open Zenoh session
+  ESP_LOGI(TAG, "Opening Zenoh Session...");
+  z_owned_session_t s;
+  if (z_open(&s, z_move(config), NULL) < 0) {
+    ESP_LOGE(TAG, "Unable to open session!");
+    exit(-1);
+  }
+  ESP_LOGI(TAG, "Opening Zenoh session was succesful!\n");
 
-    // Initialize Zenoh Session and other parameters
-    z_owned_config_t config = z_config_default();
-    zp_config_insert(z_loan(config), Z_CONFIG_MODE_KEY, z_string_make(MODE));
+  // Start the receive and the session lease loop for zenoh-pico
+  zp_start_read_task(z_loan_mut(s), NULL);
+  zp_start_lease_task(z_loan_mut(s), NULL);
 
-    if (strcmp(CONNECT, "") == 0)
-    {
-        ESP_LOGI(TAG, "CONNECT string is empty. Using scouting to find peers in the network.\n");
-    }
-    else
-    {
-        if (is_valid_tcp_url(CONNECT))
-        {
-            zp_config_insert(z_loan(config), Z_CONFIG_CONNECT_KEY,
-                             z_string_make(CONNECT));
-        }
-    }
+  ESP_LOGI(TAG, "Declaring Subscriber on '%s'...", KEYEXPR);
+  z_owned_closure_sample_t callback;
+  z_closure(&callback, data_handler, NULL, NULL);
+  z_owned_subscriber_t sub;
+  z_view_keyexpr_t ke;
+  z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
+  if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback),
+                           NULL) < 0) {
+    ESP_LOGE(TAG, "Unable to declare subscriber.");
+    exit(-1);
+  }
+  ESP_LOGI(TAG, "OK!");
 
-    // Open Zenoh session
-    ESP_LOGI(TAG, "Opening Zenoh session at %s\n", CONNECT);
-    z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
-        ESP_LOGE(TAG, "Unable to open session!\n");
-        exit(-1);
-    }
-    ESP_LOGI(TAG, "Opening Zenoh session was succesful!\n");
+  ESP_LOGI(TAG, "Declaring Publisher on '%s'...", KEYEXPR);
+  z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
+  if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
+    ESP_LOGE(TAG, "Unable to declare publisher for key expression!");
+    exit(-1);
+  }
+  ESP_LOGI(TAG, "OK");
 
-    // Start the receive and the session lease loop for zenoh-pico
-    zp_start_read_task(z_loan(s), NULL);
-    zp_start_lease_task(z_loan(s), NULL);
+  while (1) {
+    sleep(1);
+  }
 
-    ESP_LOGI(TAG, "Declaring publisher for '%s'...", KEYEXPR);
-    pub = z_declare_publisher(z_loan(s), z_keyexpr(KEYEXPR), NULL);
-    if (!z_check(pub))
-    {
-        ESP_LOGE(TAG, "Unable to declare publisher for key expression!\n");
-        exit(-1);
-    }
-    ESP_LOGI(TAG, "Successfully declared publisher for '%s'\n", KEYEXPR);
+  ESP_LOGI(TAG, "Closing Zenoh Session...");
+  z_drop(z_move(sub));
 
-    ESP_LOGI(TAG, "Declaring subscriber on '%s'...", KEYEXPR);
-    z_owned_closure_sample_t callback = z_closure(sample_handler);
-    z_owned_subscriber_t sub = z_declare_subscriber(
-        z_loan(s), z_keyexpr(KEYEXPR), z_move(callback), NULL);
-    if (!z_check(sub))
-    {
-        ESP_LOGE(TAG, "Unable to declare subscriber.\n");
-        exit(-1);
-    }
-    ESP_LOGI(TAG, "Succesfully declared subscriber on '%s'\n", KEYEXPR);
-
-    while (1)
-    {
-        sleep(1);
-    }
-
-    ESP_LOGI(TAG, "Closing Zenoh session...\n");
-    z_undeclare_subscriber(z_move(sub));
-
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan(s));
-    zp_stop_lease_task(z_loan(s));
-
-    z_close(z_move(s));
-    ESP_LOGI(TAG, "Successfully closed the Zenoh session.\n");
+  z_drop(z_move(s));
+  ESP_LOGI(TAG, "OK!");
 }
 #else
-void app_main()
-{
-    ESP_LOGI(TAG,
-             "ERROR: Zenoh pico was compiled without Z_FEATURE_PUBLICATION but "
-             "this example requires it.\n");
+void app_main() {
+  ESP_LOGE(TAG, "ERROR: Zenoh pico was compiled without Z_FEATURE_SUBSCRIPTION "
+                "but this example requires it.");
 }
 #endif

--- a/config/zenoh-kuksa-provider-config.json5
+++ b/config/zenoh-kuksa-provider-config.json5
@@ -15,6 +15,12 @@
         // The Zenoh session mode the provider will use
         mode: "peer",
 
+        connect: {
+            endpoints: [
+               "tcp/zenoh-router:7447",
+            ]
+        },
+
         listen: {
             endpoints: [
                 "tcp/0.0.0.0:14444"


### PR DESCRIPTION
This PR implements compatibility updates for zenoh-pico version 1.3.4.

Key changes:

- Removed redundant build flags due to library improvements
- Updated zenoh-kuksa-provider configuration to establish connection with the zenoh-router, ensuring proper update delivery to the actuator-provider
- adapted the actuator-provider to the major API changes in zenoh-pico