### PR TITLE
Fixed horn clients docker compose entry and refactored it with a focus on code readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ The [horn actuator provider](#embedded-horn-activator) publishes and subscribes 
 In the case of the Horn the topic is `Vehicle/Body/Horn/IsActive`.
 It is then the responsibility of the Zenoh-Kuksa-Provider to listen to these topics and forward the messages between the Zenoh network and the Kuksa Databroker using gRPC.
 
+### Dozzle
+
+(Dozzle is an open source log viewer for Docker containers)[https://dozzle.dev/guide/what-is-dozzle]. If installed, Docker Desktop can also be used to view the logs of the containers
+
 ## Quick Start
 
 ### Configuring the zenoh-kuksa-provider
@@ -65,11 +69,10 @@ As an alternative you can pull the service-to-signal repository directly by exec
 git clone --recurse-submodules https://github.com/eclipse-sdv-blueprints/service-to-signal.git
 ```
 
-2. After that, the easiest way to set up and start the services is by means of using the Docker Compose file in the top
-level directory:
+2. After that, the easiest way to set up and start the services is by means of using the Docker Compose file in the top level directory:
 
 ```bash
-docker compose -f service-to-signal-compose.yaml up --build --detach
+docker compose -f service-to-signal-compose.yaml up --detach
 ```
 
 This will pull or build (if necessary) the container images, create, and start the required components, namely:
@@ -79,26 +82,20 @@ This will pull or build (if necessary) the container images, create, and start t
 * [Kuksa-Zenoh Provider](#kuksa-zenoh-provider)
 * [Zenoh Router](#zenoh-router)
 * [Software Horn](#software-horn)
+* [Horn Client](#horn-client)
+* [Dozzle](#dozzle)
 
-You can then run the [horn client](#horn-client-app) to invoke the Horn Service.
+The [horn client](#horn-client) will be actively sending horn activation and deactivation requests to the [kuksa horn service](#horn-service-kuksa). You can view its logs
 
-1. In `components/horn-client/` run:
-
-```bash
-cargo run
-```
-
-For more details read the documentation in the [horn client Readme](./components/horn-client/README.md).
-
-This requires that you installed the [Rust toolchain](https://rustup.rs) on your computer. As an alternative you can umcomment the section for the `horn-client` in the `service-to-signal-compose.yaml` and re-deploy the modified Docker Compose setup.
-
-4. Check logs for Horn
-
-To see the status of the Horn and check whether the setup worked you can read the logs of the `software-horn`. To do this run:
+- in Dozzle at http://localhost:8080
+- inside Docker Desktop
+- on the command line with
 
 ```bash
-docker logs -f software-horn
+docker logs -f horn-client
 ```
+
+The [kuksa horn service](#horn-service-kuksa) will process these requests and update the respective VSS signal in the [kuksa databroker](#kuksa-databroker). The [software horn](#software-horn) will listen to the Zenoh topic corresponding to this VSS signal and log the horn state changes to the console, which can be viewed with the same methods listed above
 
 ### Optional: Configuring and starting the actuator provider (microcontroller implementation)
 

--- a/components/Cargo.toml
+++ b/components/Cargo.toml
@@ -30,5 +30,5 @@ log = { version = "0.4.22" }
 env_logger = { version = "0.11.5" }
 protobuf = { version = "3.5.0" }
 tokio = { version = "1.40.0" }
-up-rust = { version = "0.2.0" }
-up-transport-zenoh = { version = "0.3.0" }
+up-rust = { version = "0.7.1" }
+up-transport-zenoh = { version = "0.8.0" }

--- a/components/horn-client/Cargo.toml
+++ b/components/horn-client/Cargo.toml
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/components/horn-client/Cargo.toml
+++ b/components/horn-client/Cargo.toml
@@ -1,5 +1,6 @@
 #*******************************************************************************
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/components/horn-client/README.md
+++ b/components/horn-client/README.md
@@ -2,17 +2,22 @@
 
 The `Horn Client` package implements a Client for the Horn service over Eclipse uProtocol from the COVESA uServices. This implementation relies on Eclipse Zenoh for the transport layer of the Eclipse uProtocol communication.
 
-The client supports several configuration options that can be provided on the command line or via environment variables.
-Please use the `--help` switch to get all relevant information:
+The client supports several configuration options that can be provided on the command line or via environment variables. In this directory, run...
+
+To see all available options
 
 ```bash
 cargo run -- --help
 ```
 
-To start the client using the default configuration, execute:
+To start the client using the default configuration:
 
 ```bash
 cargo run
 ```
 
-in this directory.
+To start the client using a different configuration file:
+
+```bash
+cargo run -- --config path/to/your/config/file
+```

--- a/components/horn-client/src/config.rs
+++ b/components/horn-client/src/config.rs
@@ -1,0 +1,34 @@
+/*******************************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+
+use std::path::PathBuf;
+use up_transport_zenoh::zenoh_config;
+
+#[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Args {
+    #[arg(
+        short,
+        long,
+        env = "ZENOH_CONFIG",
+        default_value = "/zenoh-config.json5"
+    )]
+    /// A Zenoh configuration file.
+    pub config: PathBuf,
+}
+
+impl Args {
+    pub fn get_zenoh_config(&self) -> Result<zenoh_config::Config, Box<dyn std::error::Error>> {
+        // Load the config from file path
+        zenoh_config::Config::from_file(&self.config).map_err(|e| e as Box<dyn std::error::Error>)
+    }
+}

--- a/components/horn-client/src/constants.rs
+++ b/components/horn-client/src/constants.rs
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+
+// see the up-spec to learn more about what these constants represent in the world of uProtocol
+// https://github.com/eclipse-uprotocol/up-spec/blob/main/basics/uri.adoc#2-data-model
+
+/// The expected name of the deployed network location/domain that the horn service lives on
+///
+/// This value should match the name of the container in the docker compose file used to deploy
+/// the horn service
+pub const HORN_SERVICE_AUTHORITY_NAME: &str = "horn-service-kuksa";
+
+/// The expected ID that represents the horn services software component. It is simply an
+/// identifier with no deeper meaning
+///
+/// see https://github.com/COVESA/uservices/blob/main/src/main/proto/vehicle/body/horn/v1/horn_service.proto
+pub const HORN_SERVICE_ENTITY_ID: u32 = 28;
+
+/// The version of the horn services uProtocol interface
+pub const HORN_SERVICE_MAJOR_VERSION: u8 = 1;
+
+/// The identifier that maps to the horn services "ActivateHorn" RPC method
+pub const ACTIVATE_HORN_RESOURCE_ID: u16 = 0x0001;
+
+/// The identifier that maps to the horn services "DeactivateHorn" RPC method
+pub const DEACTIVATE_HORN_RESOURCE_ID: u16 = 0x0002;

--- a/components/horn-client/src/horn_client.rs
+++ b/components/horn-client/src/horn_client.rs
@@ -1,0 +1,120 @@
+/*******************************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+
+use horn_proto::horn_service::{ActivateHornRequest, ActivateHornResponse};
+use log::{error, info};
+use std::sync::Arc;
+use up_rust::{
+    communication::{CallOptions, RpcClient, UPayload},
+    LocalUriProvider, StaticUriProvider,
+};
+
+use crate::{
+    constants::{ACTIVATE_HORN_RESOURCE_ID, DEACTIVATE_HORN_RESOURCE_ID},
+    horn_requests::{
+        create_deactivate_horn_request, get_prebuilt_activation_request, PrebuiltHornRequests,
+    },
+};
+
+/// A client for interacting with the COVESA Horn service over uProtocol
+pub struct HornClient {
+    rpc_client: Arc<dyn RpcClient>,
+    uri_provider: Arc<StaticUriProvider>,
+}
+
+impl HornClient {
+    pub fn new(rpc_client: Arc<dyn RpcClient>, uri_provider: Arc<StaticUriProvider>) -> Self {
+        HornClient {
+            rpc_client,
+            uri_provider,
+        }
+    }
+
+    /// Sends a request to the vehicles horn service to activate the horn with predefined behavior
+    /// based on what [`PrebuiltHornRequests`] enum value is provided
+    pub async fn activate_horn_with_prebuilt_request(
+        &self,
+        request_type: PrebuiltHornRequests,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let activate_horn_request = get_prebuilt_activation_request(request_type);
+        self.activate_horn(activate_horn_request).await
+    }
+
+    /// Sends a request to the vehicles horn service to activate the horn with the provided
+    /// [`ActivateHornRequest`] message that defines the horn behavior
+    pub async fn activate_horn(
+        &self,
+        activate_horn_request: ActivateHornRequest,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let activate_horn_uri = self
+            .uri_provider
+            .get_resource_uri(ACTIVATE_HORN_RESOURCE_ID);
+
+        let payload = UPayload::try_from_protobuf(activate_horn_request)?;
+        match self
+            .rpc_client
+            .invoke_method(
+                activate_horn_uri.clone(),
+                CallOptions::for_rpc_request(1_000, None, None, None),
+                Some(payload),
+            )
+            .await
+        {
+            Ok(Some(payload)) => {
+                let response = payload.extract_protobuf::<ActivateHornResponse>()?;
+                info!("Activate Horn returned message: {}", response);
+                Ok(())
+            }
+            Ok(None) => {
+                info!("The activate horn request returned an empty response");
+                Ok(())
+            }
+            Err(e) => {
+                error!("The activate horn request returned the error: {:?}", e);
+                Ok(())
+            }
+        }
+    }
+
+    /// Sends a request to the vehicles horn service to deactivate the horn
+    pub async fn deactivate_horn(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let deactivate_horn_uri = self
+            .uri_provider
+            .get_resource_uri(DEACTIVATE_HORN_RESOURCE_ID);
+        let deactivate_horn_request = create_deactivate_horn_request();
+        let deactivate_payload = UPayload::try_from_protobuf(deactivate_horn_request)?;
+
+        match self
+            .rpc_client
+            .invoke_method(
+                deactivate_horn_uri.clone(),
+                CallOptions::for_rpc_request(1_000, None, None, None),
+                Some(deactivate_payload),
+            )
+            .await
+        {
+            Ok(Some(_)) => {
+                info!("The deactivate horn request returned successfully");
+                Ok(())
+            }
+            Ok(None) => {
+                error!("The deactivate horn request returned an empty response");
+                Ok(())
+            }
+            Err(e) => {
+                error!("The deactivate horn request returned the error: {:?}", e);
+                Ok(())
+            }
+        }
+    }
+}

--- a/components/horn-client/src/horn_loop.rs
+++ b/components/horn-client/src/horn_loop.rs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+
+use log::info;
+
+use crate::horn_client::HornClient;
+use crate::horn_requests::PrebuiltHornRequests;
+use crate::sleep;
+
+pub async fn example_horn_loop(horn_client: HornClient) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Activating horn for 1500 milliseconds with a sequenced horn");
+    horn_client
+        .activate_horn_with_prebuilt_request(PrebuiltHornRequests::Sequenced)
+        .await?;
+    sleep(1500).await;
+
+    info!("Deactivating horn");
+    horn_client.deactivate_horn().await?;
+
+    info!("Activating horn for 4000 milliseconds with a continuous horn");
+    horn_client
+        .activate_horn_with_prebuilt_request(PrebuiltHornRequests::Continuous)
+        .await?;
+    sleep(4000).await;
+
+    info!("Deactivating horn");
+    horn_client.deactivate_horn().await?;
+
+    Ok(())
+}

--- a/components/horn-client/src/horn_requests.rs
+++ b/components/horn-client/src/horn_requests.rs
@@ -1,0 +1,85 @@
+/*******************************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+
+use horn_proto::{
+    horn_service::{ActivateHornRequest, DeactivateHornRequest},
+    horn_topics::{HornCycle, HornMode, HornSequence},
+};
+
+pub enum PrebuiltHornRequests {
+    Sequenced,
+    Continuous,
+}
+
+pub fn get_prebuilt_activation_request(request_type: PrebuiltHornRequests) -> ActivateHornRequest {
+    match request_type {
+        PrebuiltHornRequests::Sequenced => create_sequenced_horn_request(),
+        PrebuiltHornRequests::Continuous => create_continuous_horn_request(),
+    }
+}
+
+/// Constructs a horn activation request that commands the horn to cycle through a predefined
+/// sequence of on/off durations (milliseconds).
+///   1. on: 100, off: 100
+///   2. on: 200, off: 300
+///   3. on: 100, off: 200
+///   4. on: 10000, off: 500
+fn create_sequenced_horn_request() -> ActivateHornRequest {
+    ActivateHornRequest {
+        mode: HornMode::HM_SEQUENCED.into(),
+        command: vec![HornSequence {
+            horn_cycles: vec![
+                HornCycle {
+                    on_time: 100,
+                    off_time: 100,
+                    ..Default::default()
+                },
+                HornCycle {
+                    on_time: 200,
+                    off_time: 300,
+                    ..Default::default()
+                },
+                HornCycle {
+                    on_time: 100,
+                    off_time: 200,
+                    ..Default::default()
+                },
+                HornCycle {
+                    on_time: 10000,
+                    off_time: 500,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// Constructs a horn activation request that commands the horn to sound continuously
+/// until deactivated by a separate request.
+fn create_continuous_horn_request() -> ActivateHornRequest {
+    ActivateHornRequest {
+        mode: HornMode::HM_CONTINUOUS.into(),
+        command: vec![HornSequence {
+            horn_cycles: vec![],
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// Constructs a request to simply deactivate the horn
+pub(crate) fn create_deactivate_horn_request() -> DeactivateHornRequest {
+    DeactivateHornRequest::default()
+}

--- a/components/horn-client/src/lib.rs
+++ b/components/horn-client/src/lib.rs
@@ -1,0 +1,26 @@
+/*******************************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+
+pub(crate) mod horn_client;
+pub(crate) mod horn_requests;
+
+pub mod config;
+pub mod constants;
+pub use horn_client::HornClient;
+pub mod horn_loop;
+pub mod rpc_client;
+
+/// tokio sleep wrapper for better code readability
+pub(crate) async fn sleep(milliseconds: u64) {
+    tokio::time::sleep(std::time::Duration::from_millis(milliseconds)).await;
+}

--- a/components/horn-client/src/main.rs
+++ b/components/horn-client/src/main.rs
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2024 Contributors to the Eclipse Foundation
+* Copyright (c) 2025 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
@@ -13,181 +13,30 @@
 
 use clap::Parser;
 use env_logger::Env;
-use log::error;
 use log::info;
-use std::path::PathBuf;
 use std::sync::Arc;
-use up_rust::communication::{CallOptions, InMemoryRpcClient, RpcClient, UPayload};
-use up_transport_zenoh::zenoh_config;
-use up_transport_zenoh::UPTransportZenoh;
+use up_rust::StaticUriProvider;
 
-use horn_proto::horn_service::{ActivateHornRequest, ActivateHornResponse, DeactivateHornRequest};
-use horn_proto::horn_topics::{HornCycle, HornMode, HornSequence};
-
-const HORN_SERVICE_AUTHORITY_NAME: &str = "horn-service-kuksa";
-// see https://github.com/COVESA/uservices/blob/main/src/main/proto/vehicle/body/horn/v1/horn_service.proto
-const HORN_SERVICE_ENTITY_ID: u32 = 28;
-const ACTIVATE_HORN_RESOURCE_ID: u16 = 0x0001;
-const DEACTIVATE_HORN_RESOURCE_ID: u16 = 0x0002;
+use horn_client::config::Args;
+use horn_client::constants::{
+    HORN_SERVICE_AUTHORITY_NAME, HORN_SERVICE_ENTITY_ID, HORN_SERVICE_MAJOR_VERSION,
+};
+use horn_client::horn_loop::example_horn_loop;
+use horn_client::rpc_client::create_rpc_client;
+use horn_client::HornClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     let args = Args::parse();
-
+    let uri_provider: Arc<StaticUriProvider> = Arc::new(StaticUriProvider::new(
+        HORN_SERVICE_AUTHORITY_NAME,
+        HORN_SERVICE_ENTITY_ID,
+        HORN_SERVICE_MAJOR_VERSION,
+    ));
+    let rpc_client = Arc::new(create_rpc_client(args, uri_provider.clone()).await?);
+    let horn_client = HornClient::new(rpc_client.clone(), uri_provider.clone());
     info!("Starting the client for the COVESA Horn service over uProtocol");
-
-    let transport = UPTransportZenoh::new(args.get_zenoh_config()?, "//horn_client/1/1/0")
-        .await
-        .map(Arc::new)?;
-
-    // The Zenoh transport happens to implement the
-    // traits for UTransport and LocalUriProvider,
-    // which is why it is used twice here.
-    let rpc_client = InMemoryRpcClient::new(transport.clone(), transport).await?;
-    let activate_horn_uri = up_rust::UUri::try_from_parts(
-        HORN_SERVICE_AUTHORITY_NAME,
-        HORN_SERVICE_ENTITY_ID,
-        1,
-        ACTIVATE_HORN_RESOURCE_ID,
-    )?;
-    let deactivate_horn_uri = up_rust::UUri::try_from_parts(
-        HORN_SERVICE_AUTHORITY_NAME,
-        HORN_SERVICE_ENTITY_ID,
-        1,
-        DEACTIVATE_HORN_RESOURCE_ID,
-    )?;
-    let horn_request = ActivateHornRequest {
-        mode: HornMode::HM_SEQUENCED.into(),
-        command: vec![HornSequence {
-            horn_cycles: vec![
-                HornCycle {
-                    on_time: 100,
-                    off_time: 100,
-                    ..Default::default()
-                },
-                HornCycle {
-                    on_time: 200,
-                    off_time: 300,
-                    ..Default::default()
-                },
-                HornCycle {
-                    on_time: 100,
-                    off_time: 200,
-                    ..Default::default()
-                },
-                HornCycle {
-                    on_time: 10000,
-                    off_time: 500,
-                    ..Default::default()
-                },
-            ],
-            ..Default::default()
-        }],
-        ..Default::default()
-    };
-
-    let payload = UPayload::try_from_protobuf(horn_request)?;
-    match rpc_client
-        .invoke_method(
-            activate_horn_uri.clone(),
-            CallOptions::for_rpc_request(1_000, None, None, None),
-            Some(payload),
-        )
-        .await
-    {
-        Ok(Some(payload)) => {
-            let response = payload.extract_protobuf::<ActivateHornResponse>()?;
-            info!("Activate Horn returned message: {}", response);
-        }
-        Ok(None) => info!("The activate horn request returned an empty response"),
-        Err(e) => error!("The activate horn request returned the error: {:?}", e),
-    }
-
-    // Wait before deactivating the horn
-    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
-
-    let deactivate_request = DeactivateHornRequest::default();
-
-    let deactivate_payload = UPayload::try_from_protobuf(deactivate_request)?;
-
-    match rpc_client
-        .invoke_method(
-            deactivate_horn_uri.clone(),
-            CallOptions::for_rpc_request(1_000, None, None, None),
-            Some(deactivate_payload),
-        )
-        .await
-    {
-        Ok(Some(_)) => {
-            info!("The deactivate horn request returned successfully");
-        }
-        Ok(None) => error!("The deactivate horn request returned an empty response"),
-        Err(e) => error!("The deactivate horn request returned the error: {:?}", e),
-    }
-    let horn_request = ActivateHornRequest {
-        mode: HornMode::HM_CONTINUOUS.into(),
-        command: vec![HornSequence {
-            horn_cycles: vec![],
-            ..Default::default()
-        }],
-        ..Default::default()
-    };
-
-    let payload = UPayload::try_from_protobuf(horn_request)?;
-    match rpc_client
-        .invoke_method(
-            activate_horn_uri.clone(),
-            CallOptions::for_rpc_request(1_000, None, None, None),
-            Some(payload),
-        )
-        .await
-    {
-        Ok(Some(payload)) => {
-            let value = payload.extract_protobuf::<ActivateHornResponse>()?;
-            info!(
-                "Activate Horn returned message: {}",
-                value.status.unwrap().code
-            );
-        }
-        Ok(None) => error!("The activate horn request returned an empty response"),
-        Err(e) => error!("The activate horn request returned the error: {:?}", e),
-    }
-
-    // Wait before deactivating the horn
-    tokio::time::sleep(std::time::Duration::from_millis(4000)).await;
-
-    let deactivate_request = DeactivateHornRequest::default();
-
-    let deactivate_payload = UPayload::try_from_protobuf(deactivate_request)?;
-
-    match rpc_client
-        .invoke_method(
-            deactivate_horn_uri.clone(),
-            CallOptions::for_rpc_request(1_000, None, None, None),
-            Some(deactivate_payload),
-        )
-        .await
-    {
-        Ok(Some(_)) => {
-            info!("The deactivate horn request returned successfully");
-        }
-        Ok(None) => error!("The deactivate horn request returned an empty response"),
-        Err(e) => error!("The deactivate horn request returned the error: {:?}", e),
-    }
+    example_horn_loop(horn_client).await?;
     Ok(())
-}
-
-#[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]
-pub struct Args {
-    #[arg(short, long, default_value = "zenoh-config.json5")]
-    /// A Zenoh configuration file.
-    config: PathBuf,
-}
-
-impl Args {
-    pub fn get_zenoh_config(&self) -> Result<zenoh_config::Config, Box<dyn std::error::Error>> {
-        // Load the config from file path
-        zenoh_config::Config::from_file(&self.config).map_err(|e| e as Box<dyn std::error::Error>)
-    }
 }

--- a/components/horn-client/src/main.rs
+++ b/components/horn-client/src/main.rs
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright (c) 2025 Contributors to the Eclipse Foundation
+* Copyright (c) 2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/components/horn-client/src/rpc_client.rs
+++ b/components/horn-client/src/rpc_client.rs
@@ -1,0 +1,37 @@
+/*******************************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+
+use log::{info, trace};
+use std::sync::Arc;
+use up_rust::{communication::InMemoryRpcClient, LocalUriProvider, StaticUriProvider};
+use up_transport_zenoh::UPTransportZenoh;
+
+use crate::config::Args;
+
+/// Creates an in-memory uProtocol RPC client using uProtocols Zenoh transport
+pub async fn create_rpc_client(
+    args: Args,
+    uri_provider: Arc<StaticUriProvider>,
+) -> Result<InMemoryRpcClient, Box<dyn std::error::Error>> {
+    info!("Reading Zenoh config at: {:?}", args.config);
+    let config = args.get_zenoh_config()?;
+    trace!("Using Zenoh config: {:?}", config);
+    let transport = UPTransportZenoh::builder(uri_provider.get_authority())
+        .expect("invalid authority name")
+        .with_config(config)
+        .build()
+        .await
+        .map(Arc::new)?;
+
+    Ok(InMemoryRpcClient::new(transport.clone(), uri_provider.clone()).await?)
+}

--- a/components/horn-service-kuksa/src/request_handler.rs
+++ b/components/horn-service-kuksa/src/request_handler.rs
@@ -18,6 +18,7 @@ use horn_proto::status::Status;
 use log::info;
 use protobuf::MessageField;
 use up_rust::communication::{RequestHandler, ServiceInvocationError, UPayload};
+use up_rust::UAttributes;
 
 pub(crate) struct ActivateHorn {
     tx_sequence_channel: tokio::sync::mpsc::Sender<Option<ActivateHornRequest>>,
@@ -38,6 +39,7 @@ impl RequestHandler for ActivateHorn {
     async fn handle_request(
         &self,
         _resource_id: u16,
+        _message_attributes: &UAttributes,
         request_payload: Option<UPayload>,
     ) -> Result<Option<UPayload>, ServiceInvocationError> {
         info!("Handle new request to apply horn sequence");
@@ -76,6 +78,7 @@ impl RequestHandler for DeactivateHorn {
     async fn handle_request(
         &self,
         _resource_id: u16,
+        _message_attributes: &UAttributes,
         request_payload: Option<UPayload>,
     ) -> Result<Option<UPayload>, ServiceInvocationError> {
         info!("Handle new deactivation request for the horn.");

--- a/config/horn-client-zenoh-config.json5
+++ b/config/horn-client-zenoh-config.json5
@@ -5,7 +5,7 @@
 
     endpoints: [
       // "<proto>/<address>"
-      "tcp/localhost:7447"
+      "tcp/zenoh-router:7447"
     ],
   },
 

--- a/service-to-signal-compose.yaml
+++ b/service-to-signal-compose.yaml
@@ -98,14 +98,24 @@ services:
       ZENOH_CONFIG: "/zenoh-config.json5"
     volumes:
       - "./config/software-horn-zenoh-config.json5:/zenoh-config.json5"
-#  horn-client:
-#    build:
-#      context: "./components"
-#      dockerfile: "Dockerfile.horn-client"
-#    container_name: "horn-client"
-#    image: horn-client:latest
-#    restart: unless-stopped
-#    environment:
-#      HORN_ADDRESS: "tcp/horn-service-kuksa:15000"
-#    depends_on:
-#      - horn-service-kuksa
+
+  horn-client:
+    build:
+      context: "./components"
+      dockerfile: "Dockerfile.horn-client"
+    container_name: "horn-client"
+    image: horn-client:latest
+    restart: unless-stopped
+    volumes:
+      - "./config/horn-client-zenoh-config.json5:/zenoh-config.json5"
+    depends_on:
+      - horn-service-kuksa
+    networks:
+      - "app-net"
+
+  dozzle: # https://dozzle.dev/guide/what-is-dozzle
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 8080:8080


### PR DESCRIPTION
While trying to run this blueprint locally, I noticed the docker compose functionality of `horn-client` was incomplete and even causing issues

I was having issues using `cargo run` from inside the `horn-client` components folder to connect it with the rest of the stack that I ran with `docker compose`. The `horn-client` could not connect to the network (`app-net`) that `horn-service-kuksa` was running on

## Short summary of changes

- Fixed horn-client's docker compose manifest
- Updated the README to use the horn-client through `docker compose` rather than `cargo run`
- Upgraded up-rust and up-transport-zenoh
  - the updates to `horn-service-kuksa/main.rs` and `horn-service-kuksa/request_handler.rs` are because of this upgrade 
- Added Dozzle to the docker compose manifest to view container logs

### Reason Behind Refactoring

Since this blueprint is also intended to be an example of how to use some of the Eclipse foundations projects, I also thought I would make the part of code I was working on as readable as possible. The previous code worked, but was hard to make sense of at-a-glance

Now
- Code was separated into separate modules based on area of concern to minimize the amount of code in one module. I also like to separate code like this because I believe it improves the speed at which developers read and understand the purpose of the code in each module
- Repeated functionality, such as creating instances of `ActivateHornRequest`, is encapsulated in functions
- The transport logic for sending requests is encapsulated in `HornClient` and its re-usable methods
- The actual behavior-loop the horn will be requested to perform is captured in the `horn_loop` function and executed in `main.rs`

### Dozzle Logs

I added an open source container log viewer to make viewing the software stack working easier. Docker Desktop also has this capability, but Docker Desktop is not guaranteed to be installed for everyone who attempts to build this repository

https://dozzle.dev/guide/what-is-dozzle

Here is a snippet from Dozzle showing the `horn-client` components output after running `docker compose -f service-to-signal-compose.yaml up`

<img width="2756" height="938" alt="image" src="https://github.com/user-attachments/assets/853a2300-1d38-4d41-ab10-d2b40892cbc6" />
